### PR TITLE
Option to keep bookmark even after deleting lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
                         "replace",
                         "allowDuplicates"
                     ]
+                },
+                "numberedBookmarks.keepBookmarksOnDelete": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Keep the bookmarks in the file, even if its line is deleted (move one line below)"
                 }
             }
         },

--- a/src/Sticky.ts
+++ b/src/Sticky.ts
@@ -14,7 +14,7 @@ export class Sticky {
         // if (!useStickyBookmarks) {
         //     return false;
         // }
-
+        let keepOnDelete: boolean = vscode.workspace.getConfiguration("numberedBookmarks").get("keepBookmarksOnDelete", false);
         let diffLine: number;
         let updatedBookmark: boolean = false;
 
@@ -42,7 +42,7 @@ export class Sticky {
                         }
                     }
 
-                    if (event.contentChanges[ 0 ].range.end.line - event.contentChanges[ 0 ].range.start.line > 1) {
+                    if (!keepOnDelete && (event.contentChanges[ 0 ].range.end.line - event.contentChanges[ 0 ].range.start.line > 1)) {
                         for (let i = event.contentChanges[ 0 ].range.start.line/* + 1*/; i <= event.contentChanges[ 0 ].range.end.line; i++) {
                             let index = activeBookmark.bookmarks.indexOf(i);
 
@@ -73,9 +73,15 @@ export class Sticky {
                         ((activeBookmark.bookmarks[ index ] > eventLine) && (eventcharacter > 0)) ||
                         ((activeBookmark.bookmarks[ index ] >= eventLine) && (eventcharacter === 0))
                     ) {
-                        let newLine = activeBookmark.bookmarks[ index ] + diffLine;
-                        if (newLine < 0) {
-                            newLine = 0;
+                        let newLine: number;
+
+                        if (keepOnDelete) {
+                            newLine = eventLine
+                        } else {
+                            newLine = activeBookmark.bookmarks[index] + diffLine;
+                            if (newLine < 0) {
+                                newLine = 0;
+                            }
                         }
 
                         activeBookmark.bookmarks[ index ] = newLine;


### PR DESCRIPTION
The new option, `numberedBookmarks.keepBookmarksOnDelete` is `false` by default to keep the plugin behavior consistent.

![bookmark-delete](https://user-images.githubusercontent.com/2395179/47172747-b2dbef00-d2e2-11e8-880c-cb117423ed1b.gif)
