### PR TITLE
Option to set background color of bookmarked lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
                         "replace",
                         "allowDuplicates"
                     ]
+                },
+                "numberedBookmarks.backgroundLineColor": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Specify the background color to use on a bookmarked line"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,9 @@ export function activate(context: vscode.ExtensionContext) {
     // load pre-saved bookmarks
     let didLoadBookmarks: boolean = loadWorkspaceState();
 
+    // line decoration
+    let backgroundLineColor : string = vscode.workspace.getConfiguration("numberedBookmarks").get("backgroundLineColor", "");
+
     let bookmarkDecorationType: vscode.TextEditorDecorationType[] = [];
     bookmarkDecorationType.length = MAX_BOOKMARKS;
     for (let index = 0; index < MAX_BOOKMARKS; index++) {
@@ -26,7 +29,9 @@ export function activate(context: vscode.ExtensionContext) {
         bookmarkDecorationType[ index ] = vscode.window.createTextEditorDecorationType({
             gutterIconPath: pathIcon,
             overviewRulerLane: vscode.OverviewRulerLane.Full,
-            overviewRulerColor: "rgba(1, 255, 33, 0.7)"
+            overviewRulerColor: "rgba(1, 255, 33, 0.7)",
+            backgroundColor: backgroundLineColor ? backgroundLineColor : undefined,
+            isWholeLine: backgroundLineColor ? true : false
         });
     }
 


### PR DESCRIPTION
The option `decorateWholeLine`, when `true`, paints the entire line of the color specified by `lineDecoratorColor`. The default color is a softer version of the bookmark icon color.

Take a look:
![bookmark-background](https://user-images.githubusercontent.com/2395179/47176635-790fe600-d2ec-11e8-9cf6-dbba0ae2f4e1.gif)
