### PR TITLE
Disable web extension (temporarily)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "*"
     ],
     "main": "./dist/extension-node.js",
-    "browser": "./dist/extension-web.js",
     "contributes": {
         "commands": [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,22 +58,4 @@ const nodeConfig = {
     },
 }
 
-const webConfig = {
-    ...config,
-    target: "webworker",
-    output: { // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
-        path: path.resolve(__dirname, 'dist'),
-        filename: 'extension-web.js',
-        libraryTarget: "commonjs2",
-        devtoolModuleFilenameTemplate: "../[resource-path]",
-    },
-    resolve: {
-        extensions: ['.ts', '.js'],
-        fallback: {
-            path: require.resolve('path-browserify'),
-            os: require.resolve('os-browserify/browser')
-        }
-    }
-}
-
-module.exports = [webConfig,  nodeConfig];
+module.exports = [nodeConfig];


### PR DESCRIPTION
Disable web extension temporarily, because of the issues while debugging and multi-root folder differences

Refers to #130 