### PR TITLE
Add vscode-ext skills from Awesome Copilot

### DIFF
--- a/.github/skills/vscode-ext-commands/SKILL.md
+++ b/.github/skills/vscode-ext-commands/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vscode-ext-commands
+description: 'Guidelines for contributing commands in VS Code extensions. Indicates naming convention, visibility, localization and other relevant attributes, following VS Code extension development guidelines, libraries and good practices'
+---
+
+# VS Code extension command contribution
+
+This skill helps you to contribute commands in VS Code extensions
+
+## When to use this skill
+
+Use this skill when you need to:
+- Add or update commands to your VS Code extension
+
+# Instructions
+
+VS Code commands must always define a `title`, independent of its category, visibility or location. We use a few patterns for each "kind" of command, with some characteristics, described below:
+
+* Regular commands: By default, all commands should be accessible in the Command Palette, must define a `category`, and don't need an `icon`, unless the command will be used in the Side Bar.
+
+* Side Bar commands: Its name follows a special pattern, starting with underscore (`_`) and suffixed with `#sideBar`, like `_extensionId.someCommand#sideBar` for instance. Must define an `icon`, and may or may not have some rule for `enablement`. Side Bar exclusive commands should not be visible in the Command Palette. Contributing it to the `view/title` or `view/item/context`, we must inform _order/position_ that it will be displayed, and we can use terms "relative to other command/button" in order to you identify the correct `group` to be used. Also, it's a good practice to define the condition (`when`) for the new command is visible.

--- a/.github/skills/vscode-ext-localization/SKILL.md
+++ b/.github/skills/vscode-ext-localization/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: vscode-ext-localization
+description: 'Guidelines for proper localization of VS Code extensions, following VS Code extension development guidelines, libraries and good practices'
+---
+
+# VS Code extension localization
+
+This skill helps you localize every aspect of VS Code extensions
+
+## When to use this skill
+
+Use this skill when you need to:
+- Localize new or existing contributed configurations (settings), commands, menus, views or walkthroughs
+- Localize new or existing messages or other string resources contained in extension source code that are displayed to the end user
+
+# Instructions
+
+VS Code localization is composed by three different approaches, depending on the resource that is being localized. When a new localizable resource is created or updated, the corresponding localization for all currently available languages must be created/updated.
+
+1. Configurations like Settings, Commands, Menus, Views, ViewsWelcome, Walkthrough Titles and Descriptions, defined in `package.json`
+  -> An exclusive `package.nls.LANGID.json` file, like `package.nls.pt-br.json` of Brazilian Portuguese (`pt-br`) localization
+2. Walkthrough content (defined in its own `Markdown` files)
+  -> An exclusive `Markdown` file like `walkthrough/someStep.pt-br.md` for Brazilian Portuguese localization
+3. Messages and string located in extension source code (JavaScript or TypeScript files)
+  -> An exclusive `bundle.l10n.pt-br.json` for Brazilian Portuguese localization


### PR DESCRIPTION
## Summary

Add the \scode-ext-commands\ and \scode-ext-localization\ skill definitions from the [Awesome Copilot](https://github.com/github/awesome-copilot) repository.

## Changes

- Added \.github/skills/vscode-ext-commands/SKILL.md\
- Added \.github/skills/vscode-ext-localization/SKILL.md\

Both files are copied verbatim from upstream without repo-specific adaptations.

Closes #197